### PR TITLE
json content-type bug

### DIFF
--- a/lib/mtgox.js
+++ b/lib/mtgox.js
@@ -32,7 +32,7 @@ _.extend(Mtgox.prototype, {
                 'Rest-Key': this.options.key,
                 'Rest-Sign': hmac.digest('base64'),
                 'User-Agent': 'Mozilla/4.0 (compatible; MtGox node.js client)',
-                'Content-type': 'application/x-www-form-urlencoded'
+                'Content-Type': 'application/x-www-form-urlencoded'
             }
         };
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "debug": "0.7.0",
         "num": "0.2.0",
         "underscore": "1.4.2",
-        "request": "2.11.4",
+        "request": "2.16.x",
         "nonce": "1.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
This tripped me up for a few hours today. 'request' will parse the response json and support an override of Content-Type for the outgoing body, but only in a version later than what was specified in package.json, and if the header was Content-Type or content-type, not Content-type.
